### PR TITLE
[LIMS-1693] Improve tracking label 

### DIFF
--- a/src/scaup/assets/text.py
+++ b/src/scaup/assets/text.py
@@ -1,4 +1,7 @@
-LABEL_INSTRUCTIONS_STEP_1 = "Print tracking labels, and affix one of them to the dewar"
+LABEL_INSTRUCTIONS_STEP_1 = (
+    "Print tracking labels, and affix one of them to the dewar. If you're sending multiple "
+    + "dewars, ensure the dewar code on the label matches the dewar code on the dewar."
+)
 
 LABEL_INSTRUCTIONS_STEP_2 = "Affix the other label to the dewar case"
 

--- a/src/scaup/crud/pdf.py
+++ b/src/scaup/crud/pdf.py
@@ -189,10 +189,10 @@ class TrackingLabelPages(FPDF):
 
         if self.from_lines is None:
             self.add_page()
-            self.image(CUT_HERE, x="L", y=140, w=194)
+            self.image(CUT_HERE, x="L", y=139, w=194)
 
         # If we don't have an address, display both labels in a single page
-        offset_values = [10, 145] if self.from_lines is None else [10, 10]
+        offset_values = [0, 143] if self.from_lines is None else [10, 10]
 
         # Tracking labels
         for i, offset in enumerate(offset_values):
@@ -242,10 +242,10 @@ class TrackingLabelPages(FPDF):
 
             self.image(DIAMOND_LOGO, x="L", y=7 + offset, h=15)
             self.image(THIS_SIDE_UP, x="R", y=7 + offset, w=30)
-            self.image(img, x=(self.w - 60) / 2, y=offset, h=60, w=60)
-            self.set_y(y=58 + offset)
+            self.image(img, x=(self.w - 60) / 2, y=offset, h=55, w=55)
+            self.set_y(y=54 + offset)
             self.cell(w=0, text=str(dewar.barCode), align="C")
-            self.set_y(65 + offset)
+            self.set_y(60 + offset)
 
             with self.table(
                 borders_layout="HORIZONTAL_LINES", headings_style=headings_style

--- a/src/scaup/crud/pdf.py
+++ b/src/scaup/crud/pdf.py
@@ -120,6 +120,31 @@ class TrackingLabelPages(FPDF):
         self.from_lines = from_lines
         self.to_lines = to_lines
 
+        # Only display two first local contacts, to save space
+        if len(lcs := local_contact.split(",")) > 2:
+            self.local_contact = f"{', '.join(lcs[:2])} + {len(lcs) - 2}"
+
+        self.add_page()
+
+        # Label instructions
+        self.image(DIAMOND_LOGO, x="L", y=7, h=15)
+        self.set_font("helvetica", size=26, style="B")
+        self.cell(align="R", w=0, text="Instructions", h=15, new_x="LMARGIN")
+
+        self.set_y(30)
+
+        self.add_instruction_title("1. Affix to dewar")
+        self.add_instruction_text(LABEL_INSTRUCTIONS_STEP_1)
+
+        self.add_instruction_title("2. Affix to dewar case")
+        self.add_instruction_text(LABEL_INSTRUCTIONS_STEP_2)
+
+        self.add_instruction_title("3. Affix airway bill to dewar case")
+        self.add_instruction_text(LABEL_INSTRUCTIONS_STEP_3)
+
+        self.add_instruction_title("4. Request return at the end of your session")
+        self.add_instruction_text(LABEL_INSTRUCTIONS_STEP_4)
+
     def add_instruction_title(self, text: str):
         self.set_font("helvetica", size=26, style="B")
         self.cell(
@@ -161,27 +186,6 @@ class TrackingLabelPages(FPDF):
             ("Local Contact", self.local_contact),
             ("Printed", str(date.today())),
         )
-
-        self.add_page()
-
-        # Label instructions
-        self.image(DIAMOND_LOGO, x="L", y=7, h=15)
-        self.set_font("helvetica", size=26, style="B")
-        self.cell(align="R", w=0, text="Instructions", h=15, new_x="LMARGIN")
-
-        self.set_y(30)
-
-        self.add_instruction_title("1. Affix to dewar")
-        self.add_instruction_text(LABEL_INSTRUCTIONS_STEP_1)
-
-        self.add_instruction_title("2. Affix to dewar case")
-        self.add_instruction_text(LABEL_INSTRUCTIONS_STEP_2)
-
-        self.add_instruction_title("3. Affix airway bill to dewar case")
-        self.add_instruction_text(LABEL_INSTRUCTIONS_STEP_3)
-
-        self.add_instruction_title("4. Request return at the end of your session")
-        self.add_instruction_text(LABEL_INSTRUCTIONS_STEP_4)
 
         if self.from_lines is None:
             self.add_page()

--- a/tests/shipments/test_tracking_labels.py
+++ b/tests/shipments/test_tracking_labels.py
@@ -12,11 +12,9 @@ def test_get(client):
     responses.get(f"{Config.shipping_service.url}/api/shipment_requests/1/shipments/TO_FACILITY", status=404)
 
     resp = client.get("/shipments/117/tracking-labels")
-    resp2 = client.get("/shipments/117/tracking-labels")
 
     assert resp.status_code == 200
 
-    assert resp.read() == resp2.read()
 
 
 @responses.activate


### PR DESCRIPTION
**Summary**:

This pull request changes tracking label generation, so that instructions are only included once, and that only the first two lab contacts are displayed.

**Changes**:

* Only display instructions once per set of tracking labels
* Only display first two lab contacts

**To test**:

* Create shipment with at least **two** dewars in a session with \>2 lab contacts (such as https://local-oidc-test.diamond.ac.uk:9000/proposals/bi37708/sessions/33)
* Generate tracking labels
* Ensure instructions page is only included once
* Check if only the first two lab contacts are displayed, followed by `+1`, indicating that there is another lab contact which has been omitted.
