### PR TITLE
Allow shipping service backend/frontend URLs to be set separately

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,8 @@
     "read_all_perms": ["super_admin"]
   },
   "shipping_service": {
-    "url": "https://sample-shipping-staging.diamond.ac.uk"
+    "backend_url": "https://sample-shipping-staging.diamond.ac.uk",
+    "frontend_url": "https://sample-shipping-staging.diamond.ac.uk"
   },
   "db": { "pool": 3, "overflow": 6 },
   "ispyb_api": "http://127.0.0.1:8060/api",

--- a/src/scaup/crud/pdf.py
+++ b/src/scaup/crud/pdf.py
@@ -77,7 +77,7 @@ class ConsigneeAddress(object):
             return self._consignee_cache
 
         consignee_response = ExternalRequest.request(
-            base_url=Config.shipping_service.url,
+            base_url=Config.shipping_service.backend_url,
             token=token,
             method="GET",
             url=f"/api/shipments/{shipment_id}",
@@ -287,7 +287,7 @@ def get_shipping_labels(shipment_id: int, token: str):
 
     if data[0].shipmentRequest is not None:
         response = ExternalRequest.request(
-            base_url=Config.shipping_service.url,
+            base_url=Config.shipping_service.backend_url,
             token=token,
             method="GET",
             url=f"/api/shipment_requests/{data[0].shipmentRequest}/shipments/TO_FACILITY",

--- a/src/scaup/crud/shipments.py
+++ b/src/scaup/crud/shipments.py
@@ -228,7 +228,7 @@ def build_shipment_request(shipmentId: int, token: str):
     }
 
     response = ExternalRequest.request(
-        base_url=Config.shipping_service.url,
+        base_url=Config.shipping_service.backend_url,
         token=token,
         method="POST",
         url="/api/shipment_requests/",
@@ -265,7 +265,7 @@ def get_shipment_request(shipmentId: int):
             "Shipment does not have a request assigned to it",
         )
 
-    return f"{Config.shipping_service.url}/shipment-requests/{request_id}/incoming"
+    return f"{Config.shipping_service.frontend_url}/shipment-requests/{request_id}/incoming"
 
 
 def handle_callback(shipment_id: int, callback_body: StatusUpdate):

--- a/src/scaup/utils/config.py
+++ b/src/scaup/utils/config.py
@@ -33,7 +33,8 @@ class DB:
 
 @dataclass
 class ShippingService:
-    url: str = "https://localtest.diamond.ac.uk/"
+    frontend_url: str = "https://localtest.diamond.ac.uk/"
+    backend_url: str = "https://localtest.diamond.ac.uk/"
     secret: str = "no-secret"
     callback_url: str = "https://localhost/api"
 

--- a/tests/shipments/test_create_request.py
+++ b/tests/shipments/test_create_request.py
@@ -17,7 +17,7 @@ from scaup.utils.database import inner_db
 def test_create_shipment_request(client):
     """Should create shipment request in external application"""
     responses.post(
-        f"{Config.shipping_service.url}/api/shipment_requests/",
+        f"{Config.shipping_service.backend_url}/api/shipment_requests/",
         status=201,
         json={"shipmentRequestId": 50},
     )
@@ -38,7 +38,7 @@ def test_create_shipment_request(client):
 def test_shipment_request_body(client):
     """Should send well formed body to upstream service"""
     resp_post = responses.post(
-        f"{Config.shipping_service.url}/api/shipment_requests/",
+        f"{Config.shipping_service.backend_url}/api/shipment_requests/",
         status=201,
         json={"shipmentRequestId": 50},
     )
@@ -65,7 +65,7 @@ def test_shipment_request_body(client):
 def test_shipment_request_callback(client):
     """Should send callback URL to shipping service"""
     resp_post = responses.post(
-        f"{Config.shipping_service.url}/api/shipment_requests/",
+        f"{Config.shipping_service.backend_url}/api/shipment_requests/",
         status=201,
         json={"shipmentRequestId": 50},
     )
@@ -94,7 +94,7 @@ def test_shipment_request_callback(client):
 def test_shipment_request_item_not_registered(client):
     """Should use long definition for items if item type is not registered"""
     resp_post = responses.post(
-        f"{Config.shipping_service.url}/api/shipment_requests/",
+        f"{Config.shipping_service.backend_url}/api/shipment_requests/",
         status=201,
         json={"shipmentRequestId": 50},
     )
@@ -123,7 +123,7 @@ def test_shipment_request_item_not_registered(client):
 def test_shipment_request_tlc_not_registered(client):
     """Should use placeholder dimensions if top level container type is not registered"""
     resp_post = responses.post(
-        f"{Config.shipping_service.url}/api/shipment_requests/",
+        f"{Config.shipping_service.backend_url}/api/shipment_requests/",
         status=201,
         json={"shipmentRequestId": 50},
     )
@@ -177,7 +177,7 @@ def test_unassigned(client):
 def test_request_fail(client):
     """Should not create shipment request if upstream application returns error"""
     responses.post(
-        f"{Config.shipping_service.url}/api/shipment_requests/",
+        f"{Config.shipping_service.backend_url}/api/shipment_requests/",
         status=404,
     )
 

--- a/tests/shipments/test_get_request.py
+++ b/tests/shipments/test_get_request.py
@@ -6,7 +6,7 @@ def test_get(client):
     resp = client.get("/shipments/117/request", follow_redirects=False)
 
     assert resp.status_code == 307
-    assert resp.headers["location"] == f"{Config.shipping_service.url}/shipment-requests/1/incoming"
+    assert resp.headers["location"] == f"{Config.shipping_service.frontend_url}/shipment-requests/1/incoming"
 
 
 def test_get_no_id(client):

--- a/tests/shipments/test_tracking_labels.py
+++ b/tests/shipments/test_tracking_labels.py
@@ -36,7 +36,8 @@ def test_no_top_level_containers(client):
 def test_user_address(client):
     """Should return include to/from address if these are available"""
     responses.get(
-        f"{Config.shipping_service.backend_url}/api/shipment_requests/1/shipments/TO_FACILITY", json=SHIPMENT_REQUEST_CONTENTS
+        f"{Config.shipping_service.backend_url}/api/shipment_requests/1/shipments/TO_FACILITY",
+        json=SHIPMENT_REQUEST_CONTENTS,
     )
 
     responses.get(f"{Config.shipping_service.backend_url}/api/shipments/1", json=SHIPMENT_CONTENTS, status=200)
@@ -50,7 +51,8 @@ def test_user_address(client):
 def test_user_address_no_consignee(client):
     """Should raise exception if shipment service returns 'from' address but no 'to' address"""
     responses.get(
-        f"{Config.shipping_service.backend_url}/api/shipment_requests/1/shipments/TO_FACILITY", json=SHIPMENT_REQUEST_CONTENTS
+        f"{Config.shipping_service.backend_url}/api/shipment_requests/1/shipments/TO_FACILITY",
+        json=SHIPMENT_REQUEST_CONTENTS,
     )
 
     responses.get(f"{Config.shipping_service.backend_url}/api/shipments/1", status=404)

--- a/tests/shipments/test_tracking_labels.py
+++ b/tests/shipments/test_tracking_labels.py
@@ -9,7 +9,7 @@ SHIPMENT_CONTENTS = {"consignee_address_line_1": "test", "consignee_email": "tes
 @responses.activate
 def test_get(client):
     """Should get tracking labels as a PDF"""
-    responses.get(f"{Config.shipping_service.url}/api/shipment_requests/1/shipments/TO_FACILITY", status=404)
+    responses.get(f"{Config.shipping_service.backend_url}/api/shipment_requests/1/shipments/TO_FACILITY", status=404)
 
     resp = client.get("/shipments/117/tracking-labels")
 
@@ -36,10 +36,10 @@ def test_no_top_level_containers(client):
 def test_user_address(client):
     """Should return include to/from address if these are available"""
     responses.get(
-        f"{Config.shipping_service.url}/api/shipment_requests/1/shipments/TO_FACILITY", json=SHIPMENT_REQUEST_CONTENTS
+        f"{Config.shipping_service.backend_url}/api/shipment_requests/1/shipments/TO_FACILITY", json=SHIPMENT_REQUEST_CONTENTS
     )
 
-    responses.get(f"{Config.shipping_service.url}/api/shipments/1", json=SHIPMENT_CONTENTS, status=200)
+    responses.get(f"{Config.shipping_service.backend_url}/api/shipments/1", json=SHIPMENT_CONTENTS, status=200)
 
     resp = client.get("/shipments/117/tracking-labels")
 
@@ -50,10 +50,10 @@ def test_user_address(client):
 def test_user_address_no_consignee(client):
     """Should raise exception if shipment service returns 'from' address but no 'to' address"""
     responses.get(
-        f"{Config.shipping_service.url}/api/shipment_requests/1/shipments/TO_FACILITY", json=SHIPMENT_REQUEST_CONTENTS
+        f"{Config.shipping_service.backend_url}/api/shipment_requests/1/shipments/TO_FACILITY", json=SHIPMENT_REQUEST_CONTENTS
     )
 
-    responses.get(f"{Config.shipping_service.url}/api/shipments/1", status=404)
+    responses.get(f"{Config.shipping_service.backend_url}/api/shipments/1", status=404)
 
     resp = client.get("/shipments/117/tracking-labels")
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1751](https://jira.diamond.ac.uk/browse/LIMS-1751)

**Summary**:

Since these may be different (especially when dealing with network topologies which have filters/blocks on them), anyone deploying SCAUP can now set different frontend/backend URLs.

**Changes**:

- Allow shipping service backend/frontend URLs to be set separately

**To test**:

- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/117/booking-and-labels, click "view shipping information", check if the redirect URL matches the value set in `shipping_service.frontend_url` instead of `backend_url`
