### PR TITLE
[LIMS-1790] Render temporary barcodes for dewars

### DIFF
--- a/src/scaup/assets/text.py
+++ b/src/scaup/assets/text.py
@@ -1,6 +1,10 @@
 LABEL_INSTRUCTIONS_STEP_1 = (
     "Print tracking labels, and affix one of them to the dewar. If you're sending multiple "
     + "dewars, ensure the dewar code on the label matches the dewar code on the dewar."
+    + "\n\nIf a dewar doesn't have a barcode (such as the ones on the last page) already, cut out "
+    + "the barcode on the last page and affix it to the dewar. If you're sending multiple dewars, ensure "
+    + "the dewar matches the barcode you've selected for it previously. \n\nIgnore the last page if "
+    + "you already have barcodes on your dewars."
 )
 
 LABEL_INSTRUCTIONS_STEP_2 = "Affix the other label to the dewar case"
@@ -15,4 +19,8 @@ LABEL_INSTRUCTIONS_STEP_4 = (
     "Once your session is finished, you must request for your dewars to be returned if you wish for them to be "
     + "returned to your institution. \nWhen you receive your dewar, feel free to discard any labels from the "
     + "previous steps."
+)
+
+TEMPORARY_DEWAR_TEXT = (
+    "FOR STAFF: This is a temporary barcode. Replace it with a permanent sticker before the end of the visit."
 )


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1790](https://jira.diamond.ac.uk/browse/LIMS-1790)

**Summary**:

Since eBIC may face a large number of "new", unbarcoded dewars, it would be useful to provide users with temporary barcodes until most of them have permanent stickers on.

**Changes**:

- Render temporary barcodes for dewars when printing shipping labels

**To test**:

- Go to https://local-oidc-test.diamond.ac.uk:9000/api/shipments/117/tracking-labels, check if a barcode is displayed after the shipping labels

![image](https://github.com/user-attachments/assets/66abbf9d-cbec-43c1-8a8a-9cc6292a1bdb)

