### PR TITLE
[LIMS-1535] Lock out editing pre-session information 24h before session

### DIFF
--- a/src/scaup/crud/pre_sessions.py
+++ b/src/scaup/crud/pre_sessions.py
@@ -1,11 +1,14 @@
 from fastapi import HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+from lims_utils.auth import GenericUser
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 
 from ..models.inner_db.tables import PreSession
-from ..models.pre_sessions import PreSessionIn
+from ..models.pre_sessions import PreSessionIn, PreSessionOut
 from ..utils.crud import assert_not_booked
 from ..utils.database import inner_db
+from ..utils.session import check_session_locked
 
 
 @assert_not_booked
@@ -21,11 +24,15 @@ def create_pre_session_info(shipmentId: int, params: PreSessionIn):
     return pre_session
 
 
-def get_pre_session_info(shipmentId: int):
-    pre_session_info = inner_db.session.scalar(select(PreSession).filter(PreSession.shipmentId == shipmentId))
+def get_pre_session_info(shipment_id: int, user: GenericUser, token: HTTPAuthorizationCredentials):
+    pre_session_info = inner_db.session.scalar(select(PreSession).filter(PreSession.shipmentId == shipment_id))
     if not pre_session_info:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
             "Shipment does not have a request assigned to it",
         )
-    return pre_session_info
+
+    validated_model = PreSessionOut.model_validate(pre_session_info, from_attributes=True)
+    validated_model.isLocked = check_session_locked(shipment_id, user, token)
+
+    return validated_model

--- a/src/scaup/crud/pre_sessions.py
+++ b/src/scaup/crud/pre_sessions.py
@@ -1,4 +1,3 @@
-from fastapi import HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials
 from lims_utils.auth import GenericUser
 from sqlalchemy import select
@@ -26,13 +25,10 @@ def create_pre_session_info(shipmentId: int, params: PreSessionIn):
 
 def get_pre_session_info(shipment_id: int, user: GenericUser, token: HTTPAuthorizationCredentials):
     pre_session_info = inner_db.session.scalar(select(PreSession).filter(PreSession.shipmentId == shipment_id))
-    if not pre_session_info:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND,
-            "Shipment does not have a request assigned to it",
-        )
 
-    validated_model = PreSessionOut.model_validate(pre_session_info, from_attributes=True)
-    validated_model.isLocked = check_session_locked(shipment_id, user, token)
+    validated_model = PreSessionOut(
+        details=None if pre_session_info is None else pre_session_info.details,
+        isLocked=check_session_locked(shipment_id, user, token),
+    )
 
     return validated_model

--- a/src/scaup/models/pre_sessions.py
+++ b/src/scaup/models/pre_sessions.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 class BasePreSession(BaseModel):
     details: Optional[dict[str, Any]] = None
+    isLocked: bool = False
 
 
 class PreSessionIn(BasePreSession):

--- a/src/scaup/models/pre_sessions.py
+++ b/src/scaup/models/pre_sessions.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel
 
 class BasePreSession(BaseModel):
     details: Optional[dict[str, Any]] = None
-    isLocked: bool = False
 
 
 class PreSessionIn(BasePreSession):
@@ -17,4 +16,4 @@ class PreSessionOptional(BasePreSession):
 
 
 class PreSessionOut(BasePreSession):
-    pass
+    isLocked: bool = False

--- a/src/scaup/routes/shipments.py
+++ b/src/scaup/routes/shipments.py
@@ -3,9 +3,12 @@ from typing import List
 from fastapi import APIRouter, Body, Depends, Query, status
 from fastapi.responses import RedirectResponse
 from fastapi.security import HTTPAuthorizationCredentials
+from lims_utils.auth import GenericUser
 from lims_utils.models import Paged, pagination
 
-from ..auth import Permissions, auth_scheme
+from scaup.utils.session import session_unlocked
+
+from ..auth import Permissions, User, auth_scheme
 from ..crud import containers as container_crud
 from ..crud import pdf as pdf_crud
 from ..crud import pre_sessions as ps_crud
@@ -159,9 +162,11 @@ def get_shipment_request(shipmentId=Depends(auth)):
 )
 def get_pre_session(
     shipmentId=Depends(auth),
+    user: GenericUser = Depends(User),
+    token: HTTPAuthorizationCredentials = Depends(auth_scheme),
 ):
     """Create new pre session information"""
-    return ps_crud.get_pre_session_info(shipmentId)
+    return ps_crud.get_pre_session_info(shipmentId, user, token)
 
 
 @router.put(
@@ -170,7 +175,7 @@ def get_pre_session(
     status_code=status.HTTP_201_CREATED,
 )
 def create_pre_session(
-    shipmentId=Depends(auth),
+    shipmentId=Depends(session_unlocked),
     parameters: PreSessionIn = Body(),
 ):
     """Upsert new pre session information"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-from datetime import datetime
 from unittest.mock import patch
 
 # FastAPI's server has side-effects on import. This ensures the env. vars are set beforehand
@@ -151,7 +150,7 @@ def register_responses(request):
             "sessionId": 1,
             "beamLineOperator": "John Doe",
             "beamLineName": "m03",
-            "startDate": str(datetime.now()),
-            "endDate": str(datetime.now()),
+            "startDate": "2025-07-21T01:00:00",
+            "endDate": "2025-07-24T01:00:00",
         },
     )

--- a/tests/shipments/pre_session/test_get.py
+++ b/tests/shipments/pre_session/test_get.py
@@ -18,6 +18,19 @@ def test_get(mock_user, client):
     assert resp.json() == {"details": {"name": "previous"}, "isLocked": False}
 
 
+@freeze_time("2025-07-01T15:00:00")
+@responses.activate
+@pytest.mark.parametrize("mock_user", [user], indirect=True)
+def test_get_no_pre_session(mock_user, client):
+    """Should return null if no pre session information is available"""
+
+    resp = client.get("/shipments/1/preSession")
+
+    assert resp.status_code == 200
+
+    assert resp.json() == {"details": None, "isLocked": False}
+
+
 @freeze_time("2025-07-20T15:00:00")
 @responses.activate
 @pytest.mark.parametrize("mock_user", [user], indirect=True)

--- a/tests/shipments/pre_session/test_get.py
+++ b/tests/shipments/pre_session/test_get.py
@@ -1,0 +1,31 @@
+import pytest
+import responses
+from freezegun import freeze_time
+
+from ...test_utils.users import user
+
+
+@freeze_time("2025-07-01T15:00:00")
+@responses.activate
+@pytest.mark.parametrize("mock_user", [user], indirect=True)
+def test_get(mock_user, client):
+    """Should get pre session information"""
+
+    resp = client.get("/shipments/2/preSession")
+
+    assert resp.status_code == 200
+
+    assert resp.json() == {"details": {"name": "previous"}, "isLocked": False}
+
+
+@freeze_time("2025-07-20T15:00:00")
+@responses.activate
+@pytest.mark.parametrize("mock_user", [user], indirect=True)
+def test_get_locked(mock_user, client):
+    """Should get correct lock status for pre session information"""
+
+    resp = client.get("/shipments/2/preSession")
+
+    assert resp.status_code == 200
+
+    assert resp.json() == {"details": {"name": "previous"}, "isLocked": True}

--- a/tests/shipments/pre_session/test_upsert.py
+++ b/tests/shipments/pre_session/test_upsert.py
@@ -1,10 +1,19 @@
+import pytest
+import responses
+from freezegun import freeze_time
 from sqlalchemy import select
 
 from scaup.models.inner_db.tables import PreSession
+from scaup.utils.config import Config
 from scaup.utils.database import inner_db
 
+from ...test_utils.users import admin, em_admin, user
 
-def test_create(client):
+
+@freeze_time("2025-07-01T15:00:00")
+@responses.activate
+@pytest.mark.parametrize("mock_user", [user], indirect=True)
+def test_create(mock_user, client):
     """Should create new pre session information entry"""
 
     resp = client.put(
@@ -17,7 +26,10 @@ def test_create(client):
     assert inner_db.session.scalar(select(PreSession.details).filter(PreSession.shipmentId == 1)) == {"name": "test"}
 
 
-def test_update(client):
+@freeze_time("2025-07-01T15:00:00")
+@responses.activate
+@pytest.mark.parametrize("mock_user", [user], indirect=True)
+def test_update(mock_user, client):
     """Should update pre session information entry"""
 
     resp = client.put(
@@ -28,3 +40,48 @@ def test_update(client):
     assert resp.status_code == 201
 
     assert inner_db.session.scalar(select(PreSession.details).filter(PreSession.shipmentId == 2)) == {"name": "newName"}
+
+
+@freeze_time("2025-07-20T15:00:00")
+@pytest.mark.parametrize("mock_user", [user], indirect=True)
+@responses.activate
+def test_locked(client, mock_user):
+    """Should return error if session is locked and user is not staff"""
+    resp = client.put(
+        "/shipments/2/preSession",
+        json={"details": {"name": "newName"}},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Resource can't be modified 24 hours before session"
+
+
+@freeze_time("2025-07-20T15:00:00")
+@responses.activate
+@pytest.mark.parametrize("mock_user", [admin, em_admin], indirect=True)
+def test_locked_staff(mock_user, client):
+    """Should allow staff to modify experimental parameters in locked sessions"""
+    resp = client.put(
+        "/shipments/2/preSession",
+        json={"details": {"name": "newName"}},
+    )
+
+    assert resp.status_code == 201
+
+    assert inner_db.session.scalar(select(PreSession.details).filter(PreSession.shipmentId == 2)) == {"name": "newName"}
+
+
+@pytest.mark.noregister
+@freeze_time("2025-07-20T15:00:00")
+@responses.activate
+@pytest.mark.parametrize("mock_user", [user], indirect=True)
+def test_session_unavailable(mock_user, client):
+    """Should return error if upstream service can't find session"""
+    responses.get(Config.ispyb_api.url + "/proposals/cm2/sessions/1", json={"detail": "Not found"}, status=404)
+
+    resp = client.put(
+        "/shipments/2/preSession",
+        json={"details": {"name": "newName"}},
+    )
+
+    assert resp.status_code == 424

--- a/tests/shipments/test_report.py
+++ b/tests/shipments/test_report.py
@@ -29,7 +29,7 @@ def test_get(client):
 
 
 @pytest.mark.noregister
-@responses.activate()
+@responses.activate
 def test_no_session(client):
     """Should return 404 if session is not found upstream"""
     responses.get(f"{Config.ispyb_api.url}/proposals/cm1/sessions/1", status=404)


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1535](https://jira.diamond.ac.uk/browse/LIMS-1535)

**Summary**:

Since modifying experimental parameters shortly before the session may confuse local contacts, it would be preferable to lock these out for regular users, and force them to email staff to make any further amendments.

**Changes**:

- Lock out regular users from editing pre-session information 24h before session
- Return lock state when getting pre-session information

**To test**:

Either log in as a non-staff user, or comment line 90 in src/scaup/utils/session.py. Either way, these are tested in unit tests.

- Send a PUT request to `/shipments/2/preSession`, check if 400 is returned
- Send a GET request to  `/shipments/2/preSession`, check if `isLocked` is true
- Send the same PUT request, but now as a staff member, check if it goes through successfully
