### PR TITLE
[LIMS-1541] Populate firstExperimendId and dewarRegistryId in dewars

### DIFF
--- a/src/scaup/models/top_level_containers.py
+++ b/src/scaup/models/top_level_containers.py
@@ -3,14 +3,7 @@ import uuid
 from datetime import datetime
 from typing import Any, List, Optional
 
-from pydantic import (
-    AliasChoices,
-    BaseModel,
-    ConfigDict,
-    Field,
-    computed_field,
-    field_validator,
-)
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, computed_field, field_validator
 
 from ..utils.models import BaseExternal
 
@@ -59,6 +52,9 @@ class TopLevelContainerExternal(BaseExternal):
     comments: str
     code: str
     barCode: uuid.UUID
+    firstExperimentId: int | None = None
+    weight: float = 18
+    dewarRegistryId: int | None = None
 
     @computed_field
     def facilityCode(self) -> str:

--- a/src/scaup/utils/crud.py
+++ b/src/scaup/utils/crud.py
@@ -56,13 +56,13 @@ def edit_item(
     inner_db.session.commit()
 
     if updated_item and updated_item.externalId is not None:
-        ext_obj = ExternalObject(updated_item, item_id)
+        ext_obj = ExternalObject(token, updated_item, item_id)
 
         ExternalRequest.request(
             token,
             method="PATCH",
             url=f"{ext_obj.external_link_prefix}{updated_item.externalId}",
-            json=ext_obj.item_body.model_dump(mode="json"),
+            json=ext_obj.item_body.model_dump(mode="json", exclude=ext_obj.to_exclude),
         )
 
     return updated_item

--- a/tests/shipments/top_level_containers/responses.py
+++ b/tests/shipments/top_level_containers/responses.py
@@ -9,8 +9,8 @@ def registered_dewar_callback(request: PreparedRequest):
     # Return valid response for dewar with facility code DLS-EM-0000, return 404 for all else
     dewar_id = get_match(registered_dewar_regex, request.url, 2)
 
-    if dewar_id == "DLS-EM-0000" or dewar_id == "DLS-EM-0001":
-        return (200, {}, json.dumps({}))
+    if dewar_id in ["DLS-EM-0000", "DLS-EM-0001", "DLS-4", "DLS-1"]:
+        return (200, {}, json.dumps({"dewarRegistryId": 456}))
 
     return (404, {}, "")
 

--- a/tests/utils/external/test_external_object.py
+++ b/tests/utils/external/test_external_object.py
@@ -1,0 +1,50 @@
+import copy
+from datetime import datetime
+from uuid import UUID
+
+import pytest
+import responses
+from fastapi import HTTPException
+
+from scaup.models.inner_db.tables import TopLevelContainer
+from scaup.utils.config import Config
+from scaup.utils.external import ExternalObject, _get_resource_from_ispyb
+
+base_dewar = TopLevelContainer(
+    code="DLS-EM-0001",
+    id=1,
+    shipmentId=1,
+    type="dewar",
+    name="Test_Dewar",
+    barCode=UUID(bytes=b"ffffffffffffffff"),
+    creationDate=datetime.now(),
+)
+
+
+@responses.activate
+def test_new_top_level_container(client):
+    """Should get session information from ISPyB and populate it in dewar before pushing it"""
+    dewar = ExternalObject("token", base_dewar, 1, 5)
+
+    assert dewar.item_body.firstExperimentId == 1
+    assert dewar.item_body.dewarRegistryId == 456
+
+@responses.activate
+def test_update_top_level_container(client):
+    """Should not get session ID if item has already been pushed to ISPyB"""
+    external_dewar = copy.deepcopy(base_dewar)
+    external_dewar.externalId = 1
+    dewar = ExternalObject("token", external_dewar, 1, 5)
+
+    assert dewar.item_body.firstExperimentId is None
+    assert dewar.to_exclude == {"firstExperimentId"}
+
+@responses.activate
+def test_upstream_request_fail():
+    """Should raise exception if Expeye returns invalid response"""
+    responses.get(
+        f"{Config.ispyb_api.url}/foo", status=404
+    )
+
+    with pytest.raises(HTTPException, match="Received invalid response from upstream service"):
+        _get_resource_from_ispyb("token", "/foo")

--- a/tests/utils/external/test_external_object.py
+++ b/tests/utils/external/test_external_object.py
@@ -29,6 +29,7 @@ def test_new_top_level_container(client):
     assert dewar.item_body.firstExperimentId == 1
     assert dewar.item_body.dewarRegistryId == 456
 
+
 @responses.activate
 def test_update_top_level_container(client):
     """Should not get session ID if item has already been pushed to ISPyB"""
@@ -39,12 +40,11 @@ def test_update_top_level_container(client):
     assert dewar.item_body.firstExperimentId is None
     assert dewar.to_exclude == {"firstExperimentId"}
 
+
 @responses.activate
 def test_upstream_request_fail():
     """Should raise exception if Expeye returns invalid response"""
-    responses.get(
-        f"{Config.ispyb_api.url}/foo", status=404
-    )
+    responses.get(f"{Config.ispyb_api.url}/foo", status=404)
 
     with pytest.raises(HTTPException, match="Received invalid response from upstream service"):
         _get_resource_from_ispyb("token", "/foo")


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1541](https://jira.diamond.ac.uk/browse/LIMS-1541)

**Summary**:

Session IDs and dewar registry IDs are now pushed to Expeye when updating/creating dewars in SCAUP.

**Changes**:

- Populate firstExperimendId and dewarRegistryId in dewars

**To test**:

- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/118/dewar/new/edit, add a new dewar, delete the sample on the right (you can also create a shipment from scratch, this is just quicker), click `continue`, then `continue to pre-session information`, submit the form and check if a new dewar was created in ISPyB with  `firstExperimentId` and `dewarRegistryId` populated
- Go back to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/118/dewar/new/edit, click the dewar you just created, change the dewar code, click "save" and check if the dewar registry ID has been updated in the database (the name of the dewar in SCAUP won't change)
