### PR TITLE
Display PDF even if beamline operator is missing

### DIFF
--- a/src/scaup/crud/pdf.py
+++ b/src/scaup/crud/pdf.py
@@ -110,20 +110,24 @@ class TrackingLabelPages(FPDF):
     def __init__(
         self,
         location: str,
-        local_contact: str,
+        local_contact: str | None,
         from_lines: List[str] | None = None,
         to_lines: List[str] | None = None,
     ):
         super().__init__()
         self.set_font("helvetica", size=14)
         self.location = location
-        self.local_contact = local_contact
         self.from_lines = from_lines
         self.to_lines = to_lines
 
-        # Only display two first local contacts, to save space
-        if len(lcs := local_contact.split(",")) > 2:
-            self.local_contact = f"{', '.join(lcs[:2])} + {len(lcs) - 2}"
+        if not local_contact:
+            self.local_contact = "Unknown"
+        else:
+            # Only display two first local contacts, to save space
+            if len(lcs := local_contact.split(",")) > 2:
+                self.local_contact = f"{', '.join(lcs[:2])} + {len(lcs) - 2}"
+            else:
+                self.local_contact = local_contact
 
         self.add_page()
 


### PR DESCRIPTION
**Summary**:

Previously, it was assumed that all sessions would have a beamline operator, and this would break PDF generation. This rectifies that issue.

**Changes**:

- List changes made in this pull request

**To test**:

- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi37708/sessions/24/shipments, create a new shipment, add a dewar, continue to the pre-session information page, submit the form, click "Print Tracking Labels" and check if the labels are generated with "Unknown" as the lab contact

<img width="980" height="573" alt="image" src="https://github.com/user-attachments/assets/858a88c6-6917-472a-8086-734959441361" />

