### PR TITLE
[LIMS-1937] Add option to always push samples to ISPyB

### DIFF
--- a/src/scaup/crud/samples.py
+++ b/src/scaup/crud/samples.py
@@ -10,7 +10,7 @@ from ..models.samples import OptionalSample, SampleIn, SampleOut
 from ..utils.config import Config
 from ..utils.crud import assert_not_booked, edit_item
 from ..utils.database import inner_db
-from ..utils.external import ExternalRequest
+from ..utils.external import Expeye, ExternalRequest
 from ..utils.session import retry_if_exists
 
 
@@ -34,7 +34,13 @@ def _get_protein(proteinId: int, token):
 
 @assert_not_booked
 @retry_if_exists
-def create_sample(shipmentId: int, params: SampleIn, token: str):
+def create_sample(
+    shipmentId: int,
+    params: SampleIn,
+    token: str,
+    push_to_external_db: bool = False,
+    include_suffix: bool = True,
+):
     upstream_compound = _get_protein(params.proteinId, token)
 
     clean_name = upstream_compound["name"].replace(" ", "_")
@@ -68,16 +74,25 @@ def create_sample(shipmentId: int, params: SampleIn, token: str):
             detail="Too many sample copies requested",
         )
 
+    samples_json = [
+        {
+            "shipmentId": shipmentId,
+            **params.model_dump(exclude_unset=True, exclude={"copies", "parents"}),
+            "name": (f"{params.name}_{i + sample_count}" if include_suffix else params.name),
+        }
+        for i in range(params.copies)
+    ]
+
+    if push_to_external_db:
+        for i, sample_json in enumerate(samples_json):
+            sample = Sample(**sample_json)
+
+            assert Config.ispyb_api.jwt is not None
+            ext_sample = Expeye.upsert(Config.ispyb_api.jwt, sample, None)
+            samples_json[i]["externalId"] = ext_sample["externalId"]
+
     samples = inner_db.session.scalars(
-        insert(Sample).returning(Sample),
-        [
-            {
-                "shipmentId": shipmentId,
-                **params.model_dump(exclude_unset=True, exclude={"copies"}),
-                "name": f"{params.name}_{i + sample_count}",
-            }
-            for i in range(params.copies)
-        ],
+        insert(Sample).returning(Sample).values(samples_json),
     ).all()
 
     if params.parents:
@@ -151,7 +166,9 @@ def get_samples(
         return samples
 
     ext_samples = ExternalRequest.request(
-        Config.ispyb_api.jwt, method="GET", url=f"/shipments/{ext_shipment_id}/samples?limit=100"
+        Config.ispyb_api.jwt,
+        method="GET",
+        url=f"/shipments/{ext_shipment_id}/samples?limit=100",
     )
 
     if ext_samples.status_code != 200:

--- a/src/scaup/crud/samples.py
+++ b/src/scaup/crud/samples.py
@@ -87,7 +87,6 @@ def create_sample(
         for i, sample_json in enumerate(samples_json):
             sample = Sample(**sample_json)
 
-            assert Config.ispyb_api.jwt is not None
             ext_sample = Expeye.upsert(Config.ispyb_api.jwt, sample, None)
             samples_json[i]["externalId"] = ext_sample["externalId"]
 

--- a/src/scaup/routes/shipments.py
+++ b/src/scaup/routes/shipments.py
@@ -96,9 +96,19 @@ def create_sample(
     shipmentId=Depends(auth),
     parameters: SampleIn = Body(),
     token: HTTPAuthorizationCredentials = Depends(auth_scheme),
+    pushToExternalDb: bool = Query(
+        False, description="Push sample to external DB. May create orphan samples (samples without a container)"
+    ),
+    includeSuffix: bool = Query(True, description="Include ordinal suffix in sample's name"),
 ):
     """Create new sample in shipment"""
-    return sample_crud.create_sample(shipmentId=shipmentId, params=parameters, token=token.credentials)
+    return sample_crud.create_sample(
+        shipmentId=shipmentId,
+        params=parameters,
+        token=token.credentials,
+        push_to_external_db=pushToExternalDb,
+        include_suffix=includeSuffix,
+    )
 
 
 @router.get(

--- a/src/scaup/utils/config.py
+++ b/src/scaup/utils/config.py
@@ -11,7 +11,7 @@ class ConfigurationError(Exception):
 @dataclass
 class IspybApi:
     url: str
-    jwt: str | None = None
+    jwt: str
 
 
 @dataclass


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1937](https://jira.diamond.ac.uk/browse/LIMS-1937)

**Summary**:

Previously, only full sample collections could be pushed to ISPyB. This allows samples to be pushed individually during creation

**Changes**:

- Add option to always push samples to ISPyB
- Add option to not include ordinal suffix in sample name when creating samples

**To test**:

- Send a POST request to `/shipments/1/samples?pushToExternalDb=true` with `{"proteinId": 4407}` as the body, check if a new sample with name `Protein_01_1` was created in ISPyB
- Send a POST request to `/shipments/1/samples?includeSuffix=false` with `{"proteinId": 4407}` as the body, check if a new sample was created in SCAUP's DB with no suffix in the name (or check the returned body)
