### PR TITLE
[LIMS-1980] Remove CAS-specific logic

### DIFF
--- a/src/scaup/auth/micro.py
+++ b/src/scaup/auth/micro.py
@@ -1,3 +1,4 @@
+from json import JSONDecodeError
 from typing import List, TypeVar
 
 import requests
@@ -46,7 +47,11 @@ def _get_user(token: str):
         )
 
         if response.status_code != 200:
-            raise HTTPException(status_code=response.status_code, detail=response.json().get("detail"))
+            try:
+                raise HTTPException(status_code=response.status_code, detail=response.json().get("detail"))
+            except JSONDecodeError:
+                app_logger.error(f"Microauth returned {response.status_code}: {response.text}")
+                raise HTTPException(status_code=response.status_code, detail="Failed to fetch user info from Microauth")
         return response.json()
 
 

--- a/src/scaup/utils/auth.py
+++ b/src/scaup/utils/auth.py
@@ -1,14 +1,14 @@
 from typing import Any
 
 from fastapi import HTTPException, status
-from jwt import DecodeError, ExpiredSignatureError, InvalidAudienceError, decode
+from jwt import DecodeError, decode
 from lims_utils.auth import GenericUser
 from lims_utils.logging import app_logger
 
 from .config import Config
 
 
-def is_admin(perms: list[int]):
+def is_admin(perms: list[str]):
     return bool(set(Config.auth.read_all_perms) & set(perms))
 
 
@@ -30,8 +30,8 @@ def decode_jwt(token: str, aud: str = Config.shipping_service.callback_url) -> d
         )
 
         return decoded_body
-    except (DecodeError, ExpiredSignatureError, InvalidAudienceError) as e:
-        app_logger.warning(f"Error while parsing token {token}: {e}")
+    except DecodeError as e:
+        app_logger.warning(f"Error while parsing token: {e}")
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token provided")
 
 

--- a/tests/utils/test_auth.py
+++ b/tests/utils/test_auth.py
@@ -1,6 +1,7 @@
 import jwt
 import pytest
 from fastapi import HTTPException
+from jwt.exceptions import ExpiredSignatureError, InvalidAudienceError
 
 from scaup.utils.auth import check_em_staff, check_jwt
 from scaup.utils.config import Config
@@ -33,7 +34,7 @@ def test_jwt_invalid_aud():
     """Should not allow unmatched audiences"""
     token = jwt.encode({"id": 1, "exp": 9e9, "aud": "invalid-aud"}, Config.auth.jwt_private, algorithm="ES256")
 
-    with pytest.raises(HTTPException, match="401: Invalid token provided"):
+    with pytest.raises(InvalidAudienceError):
         check_jwt(token, 1)
 
 
@@ -43,7 +44,7 @@ def test_jwt_invalid_exp():
         {"id": 1, "exp": 0, "aud": Config.shipping_service.callback_url}, Config.auth.jwt_private, algorithm="ES256"
     )
 
-    with pytest.raises(HTTPException, match="401: Invalid token provided"):
+    with pytest.raises(ExpiredSignatureError):
         check_jwt(token, 1)
 
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1980](https://jira.diamond.ac.uk/browse/LIMS-1980)

**Summary**:

Removes some CAS-specific logic from the authorisation/authentication logic

**Changes**:

- Remove CAS-specific auth/auth logic

**To test**:
This is deployed to https://ebic-scaup-test.diamond.ac.uk/, you can get a token by logging into https://ebic-scaup-test.diamond.ac.uk/, going to the storage/cookies tab in your browser's developer mode and copying it (in this case, it's the one named `__Host-sh_auth`)

- Send a request to any endpoint with a **Keycloak** token as your `Authorization: Bearer` token, check it goes through OK
- Repeat the request, but remove any letter from the token to make it invalid, check it fails
- If you have a JWT emitted by the SBLIMS team, check that it still works with SCAUP
