### PR TITLE
[LIMS-2013] Hide EORI from tracking labels

### DIFF
--- a/src/scaup/crud/pdf.py
+++ b/src/scaup/crud/pdf.py
@@ -98,7 +98,11 @@ class ConsigneeAddress(object):
                 detail="Failed to get consignee address from shipping service",
             )
 
-        to_lines = [v for k, v in consignee_response.json().items() if k.startswith("consignee_") and type(v) is str]
+        to_lines = [
+            v
+            for k, v in consignee_response.json().items()
+            if k.startswith("consignee_") and type(v) is str and not k.endswith("eori")
+        ]
 
         return to_lines
 
@@ -324,7 +328,9 @@ def get_shipping_labels(shipment_id: int, token: str):
         if response.status_code == 200:
             shipment_request = response.json()
 
-            from_lines = [line for line in shipment_request["contact"].values() if line is not None]
+            from_lines = [
+                line for field, line in shipment_request["contact"].items() if line is not None and field != "eori"
+            ]
 
             to_lines = _get_consignee_address(shipment_request["shipmentId"], token)
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2013](https://jira.diamond.ac.uk/browse/LIMS-2013)

**Summary**:

To protect potentially sensitive information, EORIs will be removed from tracking labels

**Changes**:

- Hide EORI from tracking labels

**To test**:

This may be difficult to test because of the Keycloak changes, let me know if it would be best to deploy this to test

- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100
- Create a new sample collection, just a dewar is enough
- Progress all the way to the last page (submitted), create a new shipment
- Set the country to France, use a French post code (12345) and a French EORI (FR12345678900001), complete the shipment creation process all the way, then click "Done" on the top right
- Click "booking & labels", then "view tracking labels"
- Check that no EORI is included
