### PR TITLE
[LIMS-1909] Display more information in session reports

### DIFF
--- a/src/scaup/crud/pdf.py
+++ b/src/scaup/crud/pdf.py
@@ -442,12 +442,14 @@ def generate_report(shipment_id: int, token: str):
         # Because grids is a generator, we have to count them here. This allows us to
         # access parents (and parents of parents) for all grids in a lazy-loading manner
         grid_count += 1
-        if not hasattr(grid, "container") or grid.containerId is None:
-            continue
+        puck_name: str = grid.container.parent.name if grid.container and grid.container.parent else "None"
+        gridbox_name: str = grid.container.name if grid.container else "None"
+        gridbox_location: str = str(grid.container.location) if grid.container is not None else "None"
+
         grids_table[current_row] = (
-            str(grid.container.parent.name),
-            str(grid.container.location),
-            str(grid.container.name),
+            str(puck_name),
+            str(gridbox_location),
+            str(gridbox_name),
             str(grid.location),
             str(grid.subLocation),
             str(grid.details["foil"]),

--- a/src/scaup/crud/pdf.py
+++ b/src/scaup/crud/pdf.py
@@ -387,7 +387,7 @@ class ReportPDF(FPDF):
     def add_table(
         self,
         table_contents: Sequence[tuple[str, ...]],
-        width: int = 100,
+        width: int | None = 100,
         caption: str = "Table",
         col_widths: tuple | None = None,
     ):
@@ -421,18 +421,9 @@ def generate_report(shipment_id: int, token: str):
         "Unknown" if not ispyb_session["beamLineOperator"] else ", ".join(ispyb_session["beamLineOperator"])
     )
 
-    session_table = [
-        ("Start Date", ispyb_session["startDate"]),
-        ("End Date", ispyb_session["endDate"]),
-        ("Local Contact", local_contacts),
-        ("TEM", ispyb_session["beamLineName"]),
-        ("Camera", ""),
-        ("Software", ""),
-    ]
-
     grids = inner_db.session.scalars(
         select(Sample)
-        .join(Sample.container)
+        .join(Sample.container, isouter=True)
         .filter(Sample.shipmentId == shipment_id)
         .options(contains_eager(Sample.container))
         .order_by(Sample.subLocation.desc(), Sample.containerId, Sample.location)
@@ -440,16 +431,22 @@ def generate_report(shipment_id: int, token: str):
 
     # TODO: rethink this once we're using user-provided templates
     grids_table = [
-        ("Gridbox", "Position", "Cassette Slot", "Foil", "Hole", "Comments"),
-        *[("",) * 6] * 12,
+        ("Puck", "Puck Pos.", "Gridbox", "Gridbox Pos.", "Cassette Slot", "Foil", "Hole", "Comments"),
+        *[("",) * 8] * 12,
     ]
 
     current_row = 1
+    grid_count = 0
 
     for grid in grids:
-        if not hasattr(grid, "container"):
+        # Because grids is a generator, we have to count them here. This allows us to
+        # access parents (and parents of parents) for all grids in a lazy-loading manner
+        grid_count += 1
+        if not hasattr(grid, "container") or grid.containerId is None:
             continue
         grids_table[current_row] = (
+            str(grid.container.parent.name),
+            str(grid.container.location),
             str(grid.container.name),
             str(grid.location),
             str(grid.subLocation),
@@ -458,6 +455,16 @@ def generate_report(shipment_id: int, token: str):
             str(grid.comments),
         )
         current_row += 1
+
+    session_table = [
+        ("Start Date", ispyb_session["startDate"]),
+        ("End Date", ispyb_session["endDate"]),
+        ("Local Contact", local_contacts),
+        ("TEM", ispyb_session["beamLineName"]),
+        ("Camera", ""),
+        ("Software", ""),
+        ("Number of Grids", str(grid_count)),
+    ]
 
     pre_session = inner_db.session.scalar(select(PreSession).filter(PreSession.shipmentId == shipment_id))
 
@@ -474,12 +481,16 @@ def generate_report(shipment_id: int, token: str):
     pdf.add_page()
 
     pdf.set_xy(x=5, y=20)
+    pdf.add_table(grids_table, width=None, caption="Grids", col_widths=(2, 2, 2, 2, 2, 3, 1, 4))
+
+    # There was no good way of fitting all three tables in one page, even if the grids table was as small
+    # as possible, so we always create a new page
+    pdf.add_page()
+
+    pdf.set_xy(x=5, y=20)
     pdf.add_table(session_table, width=100, caption="Session")
 
-    pdf.set_xy(x=110, y=20)
-    pdf.add_table(grids_table, width=182, caption="Grids", col_widths=(2, 1, 2, 3, 1, 2))
-
-    pdf.set_xy(x=5, y=70)
+    pdf.set_xy(x=140, y=20)
     pdf.add_table(pre_session_table, width=100, caption="Data Collection Parameters")
 
     headers = {

--- a/src/scaup/models/inner_db/tables.py
+++ b/src/scaup/models/inner_db/tables.py
@@ -95,8 +95,9 @@ class Container(Base, BaseColumns):
     isCurrent: Mapped[bool] = mapped_column(default=False, comment="Whether container position is current")
     registeredContainer: Mapped[str | None] = mapped_column()
 
+    parent: Mapped[Optional["Container"]] = relationship("Container", back_populates="children", remote_side=[id])
     topLevelContainer: Mapped[Optional["TopLevelContainer"]] = relationship(back_populates="children")
-    children: Mapped[List["Container"] | None] = relationship("Container")
+    children: Mapped[List["Container"] | None] = relationship("Container", back_populates="parent")
     samples: Mapped[List["Sample"] | None] = relationship(back_populates="container")
 
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1909](https://jira.diamond.ac.uk/browse/LIMS-1909)

**Summary**:

This adds puck name/location to the grid table, as well as the total number of grids in a session.

**Changes**:

- Display more information in session reports

**To test**:

- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/117
- Click "print contents as tables"
- Check that puck location and name are now displayed in the "grids" table, and that the total number of grids is displayed in the "session" table in the second page
