### PR TITLE
[LIMS-2025] Use SCAUP token for upserting orphan samples

### DIFF
--- a/src/scaup/crud/shipments.py
+++ b/src/scaup/crud/shipments.py
@@ -112,7 +112,10 @@ def push_shipment(shipmentId: int, token: str):
     )
 
     for sample in containerless_samples:
-        Expeye.upsert(token, sample, None, session_id)
+        # There is no way of verifying orphan sample ownership in ISPyB, so we need to use SCAUP's
+        # token instead to create them on behalf of SCAUP, which has permission to manipulate all samples.
+        # TODO: revisit this when SCAUP creates containers, dewars and shipments for orphan samples
+        Expeye.upsert(Config.ispyb_api.jwt, sample, None, session_id)
 
     modified_items = list(create_all_items_in_shipment(shipment, f"{shipment.proposalCode}{shipment.proposalNumber}"))
 

--- a/src/scaup/utils/external.py
+++ b/src/scaup/utils/external.py
@@ -177,8 +177,11 @@ class Expeye:
             ext_obj.url = f"{ext_obj.external_link_prefix}{item.externalId}"
             method = "PATCH"
 
+        # There is no way of verifying orphan sample ownership in ISPyB, so we need to use SCAUP's
+        # token instead to create them on behalf of SCAUP, which has permission to manipulate all samples.
+        # TODO: revisit this when SCAUP creates containers, dewars and shipments for orphan samples
         response = ExternalRequest.request(
-            token,
+            Config.ispyb_api.jwt,
             method=method,
             url=ext_obj.url,
             json=ext_obj.item_body.model_dump(mode="json", exclude=ext_obj.to_exclude),


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2025](https://jira.diamond.ac.uk/browse/LIMS-2025)

**Summary**:

Non-admin users may face permission issues when creating orphan samples (samples without containers), meaning that for the moment being we must create these samples on behalf of the user using SCAUP's token.

**Changes**:

- Fix pushing orphan samples to ISPyB as a non-admin user

**To test**:

This is hard to test, as it requires a non-admin user or changes to Expeye to use a dummy non-admin user for all requests

- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi23047/sessions/100/shipments/118/import-samples
- Import one of the grids
- Click "save and enter pre-session information"
- Fill in some fake data, click "finish"
- The request should not fail, then you should be redirected to the "submitted successfully" page
