### PR TITLE
[LIMS-1708] Add endpoint for creating inventory dewar

### DIFF
--- a/src/scaup/models/containers.py
+++ b/src/scaup/models/containers.py
@@ -68,7 +68,7 @@ class OptionalContainer(BaseContainer):
 
 
 class ContainerOut(BaseContainer):
-    shipmentId: int
+    shipmentId: int | None = None
     id: int = Field(validation_alias=AliasChoices("containerId", "id"))
     model_config = ConfigDict(from_attributes=True, arbitrary_types_allowed=True)
     type: str

--- a/src/scaup/models/samples.py
+++ b/src/scaup/models/samples.py
@@ -40,7 +40,7 @@ class OptionalSample(BaseSample):
 
 class SampleOut(BaseSample):
     id: int = Field(validation_alias=AliasChoices("sampleId", "id", AliasPath("Sample", "id")))
-    shipmentId: int = Field(validation_alias=InnerAlias("shipmentId"))
+    shipmentId: int | None = Field(default=None, validation_alias=InnerAlias("shipmentId"))
     proteinId: int = Field(validation_alias=InnerAlias("proteinId"))
     containerName: Optional[str] = None
     type: str = Field(validation_alias=InnerAlias("type"))

--- a/src/scaup/models/top_level_containers.py
+++ b/src/scaup/models/top_level_containers.py
@@ -14,6 +14,10 @@ class TopLevelContainerHistory(BaseModel):
     arrivalDate: datetime | None = None
 
 
+class PreloadedInventoryDewar(BaseModel):
+    name: str
+
+
 class BaseTopLevelContainer(BaseModel):
     details: Optional[dict[str, Any]] = None
     comments: Optional[str] = None

--- a/src/scaup/routes/internal.py
+++ b/src/scaup/routes/internal.py
@@ -8,7 +8,7 @@ from ..crud.containers import create_container
 from ..crud.top_level_containers import create_top_level_container
 from ..models.containers import ContainerIn, ContainerOut
 from ..models.shipments import GenericItem, ShipmentChildren
-from ..models.top_level_containers import TopLevelContainerIn, TopLevelContainerOut
+from ..models.top_level_containers import PreloadedInventoryDewar, TopLevelContainerIn, TopLevelContainerOut
 from ..utils.auth import check_em_staff
 
 
@@ -77,3 +77,13 @@ def create_orphan_top_level_container(
 def get_internal_container(topLevelContainerId: int):
     """Get internal top level container and its children"""
     return crud.get_internal_container_tree(top_level_container_id=topLevelContainerId)
+
+
+@router.post(
+    "/preloaded-dewars",
+    response_model=TopLevelContainerOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_preloaded_inventory_dewar(parameters: PreloadedInventoryDewar = Body()):
+    """Create preloaded inventory dewar with pucks and grid boxes"""
+    return crud.create_preloaded_inventory_dewar(name=parameters.name)

--- a/tests/internal/test_create_preloaded.py
+++ b/tests/internal/test_create_preloaded.py
@@ -1,0 +1,25 @@
+import pytest
+from sqlalchemy import func, select
+
+from scaup.models.inner_db.tables import Container, TopLevelContainer
+from scaup.utils.database import inner_db
+
+from ..test_utils.users import admin
+
+
+@pytest.mark.parametrize("mock_user", [admin], indirect=True)
+def test_create(mock_user, client):
+    """Should create internal preloaded dewar"""
+    resp = client.post(
+        "/internal-containers/preloaded-dewars",
+        json={"name": "foo"},
+    )
+
+    assert resp.status_code == 201
+
+    item_id = resp.json()["id"]
+
+    assert inner_db.session.scalar(select(TopLevelContainer).filter(TopLevelContainer.id == item_id)) is not None
+    assert (
+        inner_db.session.scalar(select(func.count(Container.id)).filter(Container.topLevelContainerId == item_id)) == 5
+    )


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1708](https://jira.diamond.ac.uk/browse/LIMS-1708)

**Summary**:

Since eBIC storage dewars have a standard set of containers assigned to them, we can create "pre-loaded" dewars which contain all containers an eBIC storage dewar should have.

**Changes**:

- Add endpoint for creating inventory dewar

**To test**:

- Send a POST request to `/internal-containers/preloaded-dewars` with `{"name": "foo"}` as the body, check that a new shipment was created, with one dewar, 5 pucks and 12 gridboxes
