### PR TITLE
[LIMS-2005] Perform manufacturer serial number check when creating dewars

### DIFF
--- a/src/scaup/crud/top_level_containers.py
+++ b/src/scaup/crud/top_level_containers.py
@@ -60,6 +60,15 @@ def _check_fields(
         )
 
         if code_response.status_code == 200:
+            registry_json: dict[str, Any] = code_response.json()
+            msn = registry_json.get("manufacturerSerialNumber")
+            if isinstance(params, TopLevelContainerIn) and msn is not None:
+                app_logger.error(f"{msn}, {params.manufacturerSerialNumber}")
+                if msn != params.manufacturerSerialNumber:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="Manufacturer serial number does not match the provided facility code",
+                    )
             return
 
     raise HTTPException(
@@ -114,7 +123,7 @@ def create_top_level_container(shipmentId: int | None, params: TopLevelContainer
                 url=f"/proposals/{proposal.reference}/dewar-registry",
                 json={
                     "facilityCode": new_code,
-                    "manufacturerSerialNumber": (None if params.code.lower().strip() == "n/a" else params.code),
+                    "manufacturerSerialNumber": params.manufacturerSerialNumber,
                 },
             )
 

--- a/src/scaup/models/top_level_containers.py
+++ b/src/scaup/models/top_level_containers.py
@@ -24,17 +24,17 @@ class BaseTopLevelContainer(BaseModel):
             "by the container index is used"
         ),
     )
+    code: str | None = None
 
 
 class TopLevelContainerIn(BaseTopLevelContainer):
     type: str
-    code: str = "n/a"
+    manufacturerSerialNumber: str | None = None
     isInternal: bool = False
 
 
 class OptionalTopLevelContainer(BaseTopLevelContainer):
     type: Optional[str] = None
-    code: Optional[str] = None
     barCode: Optional[str] = None
 
 

--- a/tests/shipments/test_create_item.py
+++ b/tests/shipments/test_create_item.py
@@ -21,10 +21,7 @@ creation_params = (
         ),
         pytest.param(
             "topLevelContainers",
-            {
-                "type": "dewar",
-                "code": "DLS-EM-0001",
-            },
+            {"type": "dewar", "code": "DLS-EM-0001", "manufacturerSerialNumber": "serial123"},
             TopLevelContainer,
             id="topLevelContainers",
         ),


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2005](https://jira.diamond.ac.uk/browse/LIMS-2005)

**Summary**:

To prevent users from accidentally submitting the wrong dewar, it was suggested by eBIC personnel to ask them to submit a MSN, which would be checked against the DewarRegistry table to ensure the correct MSN is used with the corresponding dewar code.

**Changes**:

- Perform manufacturer serial number check when creating dewars

**To test**:

To give one of the dewars in one of the existing shipments a manufacturer serial number, run the following in restored ISPyB:

```sql
UPDATE ispyb.DewarRegistry
	SET manufacturerSerialNumber='bar'
	WHERE dewarRegistryId=1130;
```

- Send a POST to `/shipments/{shipmentId}/topLevelContainers`, with the following body, expect 404 to be returned:

```json
{
      "type": "dewar",
      "code": "DLS-BI-9966",
      "manufacturerSerialNumber": "serial123",
}
```

- Change the manufacturer serial number to `bar` (or whatever you set it as), 201 should be returned
- Set the code to `null` and the manufacturer serial number to `new-code-123`, check if a new dewar registry entry is created with `new-code-123` as the manufacturer serial number