### PR TITLE
[LIMS-2066] More descriptive error message for sample with parent/child

### DIFF
--- a/src/scaup/routes/samples.py
+++ b/src/scaup/routes/samples.py
@@ -3,9 +3,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 
 from ..auth import Permissions, auth_scheme
 from ..crud import samples as crud
-from ..models.inner_db.tables import Sample
 from ..models.samples import OptionalSample, SampleOut
-from ..utils.crud import delete_item
 
 auth_sample = Permissions.sample
 
@@ -29,4 +27,4 @@ def edit_sample(
 @router.delete("/{sampleId}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_sample(sampleId=Depends(auth_sample)):
     """Create new sample in shipment"""
-    return delete_item(table=Sample, item_id=sampleId)
+    return crud.delete_sample(sample_id=sampleId)

--- a/tests/shipments/samples/test_delete.py
+++ b/tests/shipments/samples/test_delete.py
@@ -1,0 +1,8 @@
+def test_delete_with_parent(client):
+    """Should fail if sample is referenced in SampleParentChild"""
+
+    resp = client.delete(
+        "/samples/1877",
+    )
+
+    assert resp.status_code == 409


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2066](https://jira.diamond.ac.uk/browse/LIMS-2066)

**Summary**:

This adds a more descriptive error message for samples which can't be deleted because they have a parent/child sample associated

**Changes**:

- More descriptive error message for sample with parent/child

**To test**:

- Send a DELETE to `/samples/1877`, check if 409 is returned
