### PR TITLE
[LIMS-2107] Update dewar name when code changes

### DIFF
--- a/src/scaup/crud/top_level_containers.py
+++ b/src/scaup/crud/top_level_containers.py
@@ -187,6 +187,10 @@ def create_top_level_container(shipmentId: int | None, params: TopLevelContainer
 
 def edit_top_level_container(topLevelContainerId: int, params: OptionalTopLevelContainer, token: str):
     _check_fields(params, token, topLevelContainerId)
+
+    if params.code is not None:
+        params.name = params.code if params.name is None else params.name
+
     return edit_item(TopLevelContainer, params, topLevelContainerId, token)
 
 

--- a/tests/shipments/top_level_containers/test_edit.py
+++ b/tests/shipments/top_level_containers/test_edit.py
@@ -37,6 +37,24 @@ def test_edit_code(client):
 
 
 @responses.activate
+def test_edit_code_name(client):
+    """Should update name if code changes"""
+    resp = client.patch(
+        "/topLevelContainers/2",
+        json={"code": "DLS-EM-0000"},
+    )
+
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert data["name"] == "DLS-EM-0000"
+
+    assert (
+        inner_db.session.scalar(select(TopLevelContainer).filter(TopLevelContainer.name == "DLS-EM-0000")) is not None
+    )
+
+
+@responses.activate
 def test_edit_invalid_code(client):
     """Should not update top level container if code is not valid"""
     resp = client.patch(


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2107](https://jira.diamond.ac.uk/browse/LIMS-2107)

**Summary**:

To prevent confusion, the display name for dewars should change if the code changes, as by default, the name is the dewar code

**Changes**:

- Update dewar name when code changes

**To test**:
- Send a POST request to `/shipments/118/topLevelContainers` with `{"type": "dewar", "code": "DLS-BI-0020"}` as the body, note down the ID
- Send a PATCH request to `/topLevelContainers/{RECENTLY_CREATED_ID}` with `{"code": "DLS-BI-0022"}` as the body, check if the name changes to "DLS-BI-0022" in the database
- Send a PATCH request to `/topLevelContainers/{RECENTLY_CREATED_ID}` with `{"name": "foo", "code": "DLS-BI-0020"}` as the body, check if the name changes to "foo" in the database
