### PR TITLE
[LIMS-2100] Update shipment on cancellation

### DIFF
--- a/src/scaup/crud/shipments.py
+++ b/src/scaup/crud/shipments.py
@@ -304,8 +304,12 @@ def get_shipment_request(shipmentId: int):
 
 
 def handle_callback(shipment_id: int, callback_body: StatusUpdate):
+    columns: dict[str, str | None] = {
+        "status": callback_body.status if callback_body.status != "CREATED" else "Pickup Cancelled"
+    }
+
     updated_shipment = inner_db.session.scalar(
-        update(Shipment).returning(Shipment).filter_by(id=shipment_id).values({"status": callback_body.status})
+        update(Shipment).returning(Shipment).filter_by(id=shipment_id).values(columns)
     )
 
     inner_db.session.commit()

--- a/src/scaup/models/shipments.py
+++ b/src/scaup/models/shipments.py
@@ -79,8 +79,8 @@ class ShipmentExternal(BaseExternal):
 
 class StatusUpdate(BaseModel):
     origin_url: str
-    journey_type: str
+    journey_type: str | None = None
     status: str
-    tracking_number: str
+    tracking_number: str | None = None
     pickup_confirmation_code: str | None = None
     pickup_confirmation_timestamp: datetime | None

--- a/tests/shipments/test_update_status.py
+++ b/tests/shipments/test_update_status.py
@@ -5,7 +5,7 @@ from scaup.utils.database import inner_db
 
 
 def test_post(client):
-    """Should get shipment details as tree of generic items"""
+    """Should update shipment status"""
     resp = client.post(
         "/shipments/118/update-status",
         params={"token": ""},
@@ -24,3 +24,18 @@ def test_post(client):
     new_status = inner_db.session.scalar(select(Shipment.status).filter(Shipment.id == 118))
 
     assert new_status == "New Status"
+
+
+def test_cancelled(client):
+    """Should treat "CREATED" as a pickup cancellation"""
+    resp = client.post(
+        "/shipments/118/update-status",
+        params={"token": ""},
+        json={"status": "CREATED", "origin_url": "https://fake.com", "pickup_confirmation_timestamp": 1},
+    )
+
+    assert resp.status_code == 200
+
+    new_status = inner_db.session.scalar(select(Shipment.status).filter(Shipment.id == 118))
+
+    assert new_status == "Pickup Cancelled"


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2100](https://jira.diamond.ac.uk/browse/LIMS-2100)

**Summary**:

This PR makes it so shipments are updated when a cancellation is triggered in the shipping service

**Changes**:

- Update shipment on cancellation

**To test**:

This is available on `ebic-scaup-test` for easier testing

- Go to https://ebic-scaup-test.diamond.ac.uk/proposals/bi23047/sessions/104
- Create a new shipment, add a single dewar, click continue, continue to the pre-session page, then submit it
- Click "arrange shipment", go through the process, check that after the airway bill was successfully generated, it says "booked" on https://ebic-scaup-test.diamond.ac.uk/proposals/bi23047/sessions/104
- Go to the shipment you just created, click "Booking & Labels", click "view shipping information"
- Cancel the shipment, go back to https://ebic-scaup-test.diamond.ac.uk/proposals/bi23047/sessions/104, check that it now says "pickup cancelled"
