### PR TITLE
[LIMS-2102] Relay staff email address to shipping service

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,8 @@
   },
   "shipping_service": {
     "backend_url": "https://sample-shipping-staging.diamond.ac.uk",
-    "frontend_url": "https://sample-shipping-staging.diamond.ac.uk"
+    "frontend_url": "https://sample-shipping-staging.diamond.ac.uk",
+    "staff_email": "guilherme.de-freitas@diamond.ac.uk"
   },
   "alerts": {
     "contact_email": "pato@diamond.ac.uk",

--- a/src/scaup/crud/shipments.py
+++ b/src/scaup/crud/shipments.py
@@ -252,6 +252,7 @@ def build_shipment_request(shipmentId: int, token: str):
     )
 
     built_request_body = {
+        "staff_notification_email": Config.shipping_service.staff_email,
         "session_number": shipment.visitNumber,
         "proposal": proposal_reference,
         "external_id": shipment.externalId,

--- a/src/scaup/utils/config.py
+++ b/src/scaup/utils/config.py
@@ -37,6 +37,7 @@ class ShippingService:
     backend_url: str = "https://localtest.diamond.ac.uk/"
     secret: str = "no-secret"
     callback_url: str = "https://localhost/api"
+    staff_email: str | None = None
 
 
 @dataclass


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2102](https://jira.diamond.ac.uk/browse/LIMS-2102)

**Summary**:

To keep staff in the loop, a second email (to which international shipment notifications will be sent) can be specified 

**Changes**:

- Relay staff email address to shipping service

**To test**:

For ease of testing, this is hosted at https://ebic-scaup-test.diamond.ac.uk/

- Go to https://ebic-scaup-test.diamond.ac.uk/proposals/bi23047/sessions/102, create a new shipment, add a dewar and proceed until you get to the step where you can arrange shipping
- Set the country to France, the EORI to FR123456789 (or any valid French EORI) and the post code to 75008 (or any valid French post code)
- Continue until you submit the shipment, currently, this app is configured to forward emails to me, so I should receive an email. If you want to check for yourself, let me know and I'll redeploy with your email as a target