### PR TITLE
Disallow long names

### DIFF
--- a/src/scaup/crud/samples.py
+++ b/src/scaup/crud/samples.py
@@ -76,6 +76,14 @@ def create_sample(
             detail="Too many sample copies requested",
         )
 
+    # This is because of ISPyB - it does not allow sample names longer than 45 characters, and we add a suffix of at
+    # least 2 characters for duplicates
+    if params.name and len(params.name) > 43:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Combination of macromolecule prefix and name must not be longer than 43 characters.",
+        )
+
     samples_json = [
         {
             "shipmentId": shipmentId,

--- a/src/scaup/models/containers.py
+++ b/src/scaup/models/containers.py
@@ -25,8 +25,9 @@ class BaseContainer(BaseModel):
     name: Optional[str] = Field(
         default=None,
         description=(
-            "Base container name. If name is not provided, the container's type followedby the container index is used"
+            "Base container name. If name is not provided, the container's type followed by the container index is used"
         ),
+        max_length=45,  # Because of ISPyB
     )
     comments: Optional[str] = None
 

--- a/src/scaup/models/samples.py
+++ b/src/scaup/models/samples.py
@@ -22,6 +22,7 @@ class BaseSample(BaseModelWithNameValidator):
         default=None,
         description=("Sample name, if not provided, the provided protein's name followed by the sample index is used"),
         validation_alias=InnerAlias("name"),
+        max_length=45,  # Because of ISPyB
     )
 
 

--- a/src/scaup/models/shipments.py
+++ b/src/scaup/models/shipments.py
@@ -3,7 +3,7 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from ..utils.models import BaseExternal
+from ..utils.models import BaseExternal, IspybCompliantName
 
 type SessionTypeName = Literal["TEM", "Aquilos"]
 
@@ -26,7 +26,7 @@ class SessionType(BaseModel):
 
 
 class ShipmentIn(BaseModel):
-    name: str
+    name: IspybCompliantName
     comments: Optional[str] = None
     # This is to make the API more user-friendly, the session type is stored as an ID in the database
     sessionType: SessionTypeName = Field(default="TEM", description="Session type for the shipment")

--- a/src/scaup/utils/models.py
+++ b/src/scaup/utils/models.py
@@ -1,7 +1,9 @@
 import re
-from typing import Optional
+from typing import Annotated, Optional
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+type IspybCompliantName = Annotated[str, Field(max_length=45)]  # Because of ISPyB
 
 
 class BaseModelWithNameValidator(BaseModel):

--- a/tests/shipments/samples/test_create.py
+++ b/tests/shipments/samples/test_create.py
@@ -273,3 +273,15 @@ def test_invalid_parent(client):
     )
 
     assert resp.status_code == 404
+
+
+@responses.activate
+def test_long_name(client):
+    """Should return error if name is too long"""
+
+    resp = client.post(
+        "/shipments/1/samples",
+        json={"containerId": 4, "proteinId": 4407, "name": "a" * 35},
+    )
+
+    assert resp.status_code == 400


### PR DESCRIPTION
**Summary**:

As users have been using extremely long names (which fail when pushed to ISPyB), an extra check has to be performed, which disallows names longer than 45 characters for samples

Since sample names are formed by joining the macromolecule's name to the user-provided name, this check is performed after prepending the macromolecule name

I've decided not to push these changes to the database as there are names with over 45 characters in there, and I'm still not sure if we should bump up the limit in ISPyB

**Changes**:

- Limit names to 45 characters

**To test**:

Assuming you're using the local test database:

- Send a POST request to `/shipments/117/samples` with `{"proteinId": 338108, "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }` as the body, check if a 400 is returned
- Replace the name with a valid name (such as "foo"), check that it works as expected
