### PR TITLE
[LIMS-1851] Limit number of sample collections that can be created by user

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,7 +18,7 @@
       "Dr John Doe": "john@diamond.ac.uk"
     }
   },
-  "db": { "pool": 3, "overflow": 6 },
+  "db": { "pool": 3, "overflow": 6, "max_shipments_per_session": 2 },
   "ispyb_api": "http://127.0.0.1:8060/api",
   "frontend_url": "http://localtest.diamond.ac.uk:9000"
 }

--- a/src/scaup/crud/proposals.py
+++ b/src/scaup/crud/proposals.py
@@ -40,7 +40,7 @@ def create_shipment(
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
             f"Only {Config.db.max_shipments_per_session} sample collections are allowed per session. Contact"
-            "staff if you require more.",
+            " staff if you require more.",
         )
 
     new_shipment = inner_db.session.scalar(

--- a/src/scaup/crud/proposals.py
+++ b/src/scaup/crud/proposals.py
@@ -2,22 +2,46 @@ from typing import List
 
 from fastapi import HTTPException, status
 from lims_utils.models import Paged, ProposalReference
-from sqlalchemy import insert, select
+from sqlalchemy import func, insert, select
 from sqlalchemy.exc import MultipleResultsFound
 
+from ..auth import GenericUser
 from ..models.inner_db.tables import Sample, SessionType, Shipment
 from ..models.samples import SublocationAssignment
 from ..models.shipments import ShipmentIn
+from ..utils.auth import is_admin
+from ..utils.config import Config
 from ..utils.crud import assign_dcg_to_sublocation
 from ..utils.database import inner_db
 from ..utils.external import update_shipment_statuses
 
 
-def create_shipment(proposal_reference: ProposalReference, params: ShipmentIn):
+def create_shipment(
+    proposal_reference: ProposalReference,
+    params: ShipmentIn,
+    user: GenericUser | None = None,
+):
     # Proposal existence is already checked by Microauth
     session_type_id = inner_db.session.execute(
         select(SessionType.id).filter(SessionType.name == params.sessionType)
     ).scalar_one()
+
+    existing_shipment_count = inner_db.session.scalar(
+        select(func.count(Shipment.id)).filter(
+            Shipment.proposalCode == proposal_reference.code,
+            Shipment.proposalNumber == proposal_reference.number,
+            Shipment.visitNumber == proposal_reference.visit_number,
+        )
+    )
+
+    if existing_shipment_count > (Config.db.max_shipments_per_session - 1) and not (
+        user and is_admin(user.permissions)
+    ):
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            f"Only {Config.db.max_shipments_per_session} sample collections are allowed per session. Contact"
+            "staff if you require more.",
+        )
 
     new_shipment = inner_db.session.scalar(
         insert(Shipment).returning(Shipment),

--- a/src/scaup/routes/proposals.py
+++ b/src/scaup/routes/proposals.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Body, Depends, Query, status
 from fastapi.security import HTTPAuthorizationCredentials
 from lims_utils.models import Paged, ProposalReference, pagination
 
-from ..auth import Permissions, auth_scheme
+from ..auth import GenericUser, Permissions, User, auth_scheme
 from ..crud import containers as containers_crud
 from ..crud import proposals as crud
 from ..crud import samples as samples_crud
@@ -29,9 +29,10 @@ router = APIRouter(
 def create_shipment(
     proposalReference: ProposalReference = Depends(auth),
     parameters: ShipmentIn = Body(),
+    user: GenericUser = Depends(User),
 ):
     """Create new shipment in session"""
-    return crud.create_shipment(proposal_reference=proposalReference, params=parameters)
+    return crud.create_shipment(proposal_reference=proposalReference, params=parameters, user=user)
 
 
 @router.get(

--- a/src/scaup/utils/config.py
+++ b/src/scaup/utils/config.py
@@ -29,6 +29,7 @@ class Auth:
 class DB:
     pool: int = 10
     overflow: int = 20
+    max_shipments_per_session: int = 2
 
 
 @dataclass

--- a/tests/proposals/test_create_shipment.py
+++ b/tests/proposals/test_create_shipment.py
@@ -1,8 +1,11 @@
+import pytest
 import responses
 from sqlalchemy import select
 
 from scaup.models.inner_db.tables import Shipment
 from scaup.utils.database import inner_db
+
+from ..test_utils.users import admin, user
 
 
 @responses.activate
@@ -13,3 +16,21 @@ def test_create(client):
     assert resp.status_code == 201
 
     assert inner_db.session.scalar(select(Shipment).filter(Shipment.name == "New Shipment")) is not None
+
+
+@pytest.mark.parametrize("mock_user", [user], indirect=True)
+@responses.activate
+def test_quantity_limit(mock_user, client):
+    """Should not allow more than two sample collections per session for non-admin users"""
+    resp = client.post("/proposals/bi23047/sessions/100/shipments", json={"name": "New Shipment"})
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.parametrize("mock_user", [admin], indirect=True)
+@responses.activate
+def test_quantity_limit_admin(mock_user, client):
+    """Should allow more than two sample collections per session for admin users"""
+    resp = client.post("/proposals/bi23047/sessions/100/shipments", json={"name": "New Shipment"})
+
+    assert resp.status_code == 201


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1851](https://jira.diamond.ac.uk/browse/LIMS-1851)

**Summary**:

Since eBIC can only comport a limited number of dewars per shipment (due to space/logistical limitations), users are asked to not send more than 2 dewars, or to contact a member of staff before doing so. This enforces this in SCAUP

**Changes**:

- Limit number of sample collections that can be created by user

**To test**:

- Send a POST request to `/proposals/bi23047/sessions/100/shipments` with `{"name": "New Shipment"}` as the body, check if you can create it (as a member of staff)
- Repeat, but comment out the second part of the check in line 37 of `src/scaup/crud/proposals.py`, check if a 403 error is returned
